### PR TITLE
🐛 FIX: removed empty content on tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,12 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: [
-    './pages/**/*.{js,ts,jsx,tsx}',
-    './components/**/*.{js,ts,jsx,tsx}',
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
   ],
-  content: [],
   theme: {
     extend: {},
   },
   plugins: [],
-}
+};


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/61621124/179392891-9403a272-36e7-4a6b-b7ac-e5c598fd9cc3.png)

removed empty config causing warn